### PR TITLE
feat: commit to pr flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
           upper_threshold: 90
 ```
 
-> [!IMPORTANT] 
+> [!IMPORTANT]
 > With this setup, this action will assume, that your projects have
 > up-to-date coverage. This can be achieved by either running the tests like
 > `flutter test --coverage` in the steps before this action, or always running
@@ -134,6 +134,8 @@ what they do.
   or "total".
 - `generate_badges` (optional, default: `true`): Whether to generate badges for
   the coverage on 'push' workflow triggers.
+- `commit_to_pull_request` (optional, default: `false`): Whether to commit the
+  generated badge to the pull request, additionally to the sticky comment.
 
 ## Honorable mentions
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Whether to generate badges for the coverage on 'push' workflow triggers. Defaults to true."
     default: "true"
     required: false
+  commit_to_pull_request:
+    description: "Whether to commit the generated badge to the pull request, additionally to the sticky comment. Defaults to false."
+    default: "false"
+    required: false
 
 # Define your outputs here.
 outputs:

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,10 @@ export class Config {
     return getInput('generate_badges') === 'true'
   }
 
+  static get commitToPullRequest(): boolean {
+    return getInput('commit_to_pull_request') === 'true'
+  }
+
   private static parseCoverageRule(rule: string): CoverageRule {
     switch (rule) {
       case 'none':


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Status

My PR is **READY**

## Description

<!--- Describe your changes in detail -->

In some cases, I would like the Coverage Bot to not only comment the new coverage badge to the PR, but also commit it to the PR's branch. For instance, if I have branch protection in place that disallows direct pushes to the main branch without a pull request, the coverage badge never gets updated because the commit of the bot always gets declined.

This is where the `commit_to_pull_request` flag comes into play and solves our problem by committing to the PR's branch.

Grüße aus dem Office 👻

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
